### PR TITLE
fixed rare FullEvalFormatter problem envolving '!'

### DIFF
--- a/IPython/utils/text.py
+++ b/IPython/utils/text.py
@@ -556,6 +556,9 @@ class FullEvalFormatter(Formatter):
                 # the formatting
 
                 if format_spec:
+                   if conversion:
+                      # override conversion spec
+                      field_name = '!'.join([field_name, conversion])
                     # override format spec, to allow slicing:
                     field_name = ':'.join([field_name, format_spec])
 


### PR DESCRIPTION
Formatter.parse returns a single character in `conversion` if '!c:' exists in the format_string for some character 'c'. This edit puts it back.

btw: string.Formatter.parse() will throw an exception if an '!' is in the format_string without the 'c:' part.
